### PR TITLE
Remove accidentally imported class

### DIFF
--- a/src/Markup/ChildRendererTrait.php
+++ b/src/Markup/ChildRendererTrait.php
@@ -12,7 +12,6 @@ namespace DecodeLabs\Elementary\Markup;
 use DecodeLabs\Coercion;
 use DecodeLabs\Elementary\Buffer;
 use DecodeLabs\Elementary\Element;
-use DecodeLabs\Elementary\Tag;
 use DecodeLabs\Elementary\Markup;
 use Generator;
 


### PR DESCRIPTION
Seen the diff from latest release.

Shouldn't Effigy fix this?